### PR TITLE
improve `/health` endpoint informations

### DIFF
--- a/cmd/service-discovery/commands/root.go
+++ b/cmd/service-discovery/commands/root.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	cc "github.com/ivanpirog/coloredcobra"
 	"github.com/skycoin/dmsg/pkg/direct"
@@ -184,6 +185,13 @@ var RootCmd = &cobra.Command{
 			}
 
 			defer closeDmsgDC()
+
+			go func() {
+				for {
+					sdAPI.DmsgServers = dmsgDC.ConnectedServersPK()
+					time.Sleep(time.Second)
+				}
+			}()
 
 			go dmsghttp.UpdateServers(ctx, dClient, dmsgDisc, dmsgDC, log)
 

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/ivanpirog/coloredcobra v1.0.1
 	github.com/lib/pq v1.10.9
 	github.com/sirupsen/logrus v1.9.3
-	github.com/skycoin/dmsg v1.3.12-0.20231120175607-0b6d5135bbc5
+	github.com/skycoin/dmsg v1.3.12-0.20231130180155-65d707cd1b01
 	github.com/skycoin/skycoin v0.27.1
 	github.com/skycoin/skywire v1.3.14-0.20231120181804-7c5994927a04
 	github.com/skycoin/skywire-utilities v0.0.0-20231120175000-12be4345eb26

--- a/go.sum
+++ b/go.sum
@@ -207,8 +207,6 @@ github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMB
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
-github.com/skycoin/dmsg v1.3.12-0.20231120175607-0b6d5135bbc5 h1:yGTInFb9SqchM5w0RrFA4vgq9tzhKQStURpetUor+4s=
-github.com/skycoin/dmsg v1.3.12-0.20231120175607-0b6d5135bbc5/go.mod h1:HPGbmjaaKzGGOL8B0Rksc9+asBEAjnmPkJ2t1Hfl+uI=
 github.com/skycoin/dmsg v1.3.12-0.20231130180155-65d707cd1b01 h1:dZD0r4a6pyCpyMYzQxdatmmTScpNj0gYlPQghKfBKes=
 github.com/skycoin/dmsg v1.3.12-0.20231130180155-65d707cd1b01/go.mod h1:HPGbmjaaKzGGOL8B0Rksc9+asBEAjnmPkJ2t1Hfl+uI=
 github.com/skycoin/noise v0.0.0-20180327030543-2492fe189ae6 h1:1Nc5EBY6pjfw1kwW0duwyG+7WliWz5u9kgk1h5MnLuA=

--- a/go.sum
+++ b/go.sum
@@ -209,6 +209,8 @@ github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/skycoin/dmsg v1.3.12-0.20231120175607-0b6d5135bbc5 h1:yGTInFb9SqchM5w0RrFA4vgq9tzhKQStURpetUor+4s=
 github.com/skycoin/dmsg v1.3.12-0.20231120175607-0b6d5135bbc5/go.mod h1:HPGbmjaaKzGGOL8B0Rksc9+asBEAjnmPkJ2t1Hfl+uI=
+github.com/skycoin/dmsg v1.3.12-0.20231130180155-65d707cd1b01 h1:dZD0r4a6pyCpyMYzQxdatmmTScpNj0gYlPQghKfBKes=
+github.com/skycoin/dmsg v1.3.12-0.20231130180155-65d707cd1b01/go.mod h1:HPGbmjaaKzGGOL8B0Rksc9+asBEAjnmPkJ2t1Hfl+uI=
 github.com/skycoin/noise v0.0.0-20180327030543-2492fe189ae6 h1:1Nc5EBY6pjfw1kwW0duwyG+7WliWz5u9kgk1h5MnLuA=
 github.com/skycoin/noise v0.0.0-20180327030543-2492fe189ae6/go.mod h1:UXghlricA7J3aRD/k7p/zBObQfmBawwCxIVPVjz2Q3o=
 github.com/skycoin/skycoin v0.27.1 h1:HatxsRwVSPaV4qxH6290xPBmkH/HgiuAoY2qC+e8C9I=

--- a/pkg/service-discovery/api/api.go
+++ b/pkg/service-discovery/api/api.go
@@ -52,9 +52,10 @@ const (
 
 // HealthCheckResponse is struct of /health endpoint
 type HealthCheckResponse struct {
-	BuildInfo *buildinfo.Info `json:"build_info,omitempty"`
-	StartedAt time.Time       `json:"started_at"`
-	DmsgAddr  string          `json:"dmsg_address,omitempty"`
+	BuildInfo   *buildinfo.Info `json:"build_info,omitempty"`
+	StartedAt   time.Time       `json:"started_at"`
+	DmsgAddr    string          `json:"dmsg_address,omitempty"`
+	DmsgServers []string        `json:"dmsg_servers,omitempty"`
 }
 
 // WhitelistPKs store whitelisted pks of network monitor
@@ -71,6 +72,7 @@ type API struct {
 	geoFromIP                   geo.LocationDetails
 	startedAt                   time.Time
 	dmsgAddr                    string
+	DmsgServers                 []string
 }
 
 // New creates an API.
@@ -86,6 +88,7 @@ func New(log logrus.FieldLogger, db store.Store, nonceDB httpauth.NonceStore, ap
 		geoFromIP:                   geo.MakeIPDetails(log, apiKey),
 		startedAt:                   time.Now(),
 		dmsgAddr:                    dmsgAddr,
+		DmsgServers:                 []string{},
 	}
 	return api
 }
@@ -437,9 +440,10 @@ func (a *API) writeError(w http.ResponseWriter, r *http.Request, status int, err
 func (a *API) health(w http.ResponseWriter, r *http.Request) {
 	info := buildinfo.Get()
 	a.writeJSON(w, r, http.StatusOK, HealthCheckResponse{
-		BuildInfo: info,
-		StartedAt: a.startedAt,
-		DmsgAddr:  a.dmsgAddr,
+		BuildInfo:   info,
+		StartedAt:   a.startedAt,
+		DmsgAddr:    a.dmsgAddr,
+		DmsgServers: a.DmsgServers,
 	})
 }
 

--- a/vendor/github.com/skycoin/dmsg/pkg/dmsg/client.go
+++ b/vendor/github.com/skycoin/dmsg/pkg/dmsg/client.go
@@ -472,6 +472,16 @@ func (ce *Client) AllEntries(ctx context.Context) (entries []string, err error) 
 	return entries, err
 }
 
+// ConnectedServersPK return keys of all connected dmsg servers
+func (ce *Client) ConnectedServersPK() []string {
+	sessions := ce.allClientSessions(ce.porter)
+	addrs := make([]string, len(sessions))
+	for i, s := range sessions {
+		addrs[i] = s.RemotePK().String()
+	}
+	return addrs
+}
+
 // ConnectionsSummary associates connected clients, and the servers that connect such clients.
 // Key: Client PK, Value: Slice of Server PKs
 type ConnectionsSummary map[cipher.PubKey][]cipher.PubKey

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -188,7 +188,7 @@ github.com/quic-go/quic-go/quicvarint
 ## explicit; go 1.13
 github.com/sirupsen/logrus
 github.com/sirupsen/logrus/hooks/syslog
-# github.com/skycoin/dmsg v1.3.12-0.20231120175607-0b6d5135bbc5
+# github.com/skycoin/dmsg v1.3.12-0.20231130180155-65d707cd1b01
 ## explicit; go 1.18
 github.com/skycoin/dmsg/internal/servermetrics
 github.com/skycoin/dmsg/pkg/direct


### PR DESCRIPTION
Fix: #10 

Changes: 
- add `dmsg_servers` info to `/health` endpoint
- update `dmsg` to develop

How to test:
Check here: https://github.com/skycoin/skywire-services/pull/33

